### PR TITLE
59 implementar el action para generar y publicar el paquete npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,4 +72,4 @@ jobs:
 
       # Publish npm package into private github registry
       - name: Publish npm package
-        run: pnpm publish --provenance
+        run: pnpm publish


### PR DESCRIPTION
Remuevo `--provnance` ya que requiere que la primera vez que se publica usemos el flag `--access public`, pero no es posible porque el paquete debe permanecer privado

[https://docs.npmjs.com/generating-provenance-statements](https://docs.npmjs.com/generating-provenance-statements)

